### PR TITLE
Duplicate engine

### DIFF
--- a/src-tauri/src/main_options/truck_engines.rs
+++ b/src-tauri/src/main_options/truck_engines.rs
@@ -95,8 +95,6 @@ pub const SCANIA_R_2009_ENGINES: [EngineStruct; 14] = [
     SCANIA_R_2009_560,
     SCANIA_R_2009_620,
     SCANIA_R_2009_730,
-    SCANIA_R_2009_730,
-    SCANIA_R_2009_730,
 ];
 
 pub const SCANIA_STREAMLINE_ENGINES: [EngineStruct; 19] = [


### PR DESCRIPTION
This PR fixes an issue where a duplicate engine was detected when selecting Scania R 2009 engines.

![image](https://github.com/user-attachments/assets/4b2a549d-80c4-4d78-a5ae-5221aac69ba2)
